### PR TITLE
Stop using `ChocolateyPackageVersion` for constructing download url

### DIFF
--- a/.github/workflows/monthly-release.yaml
+++ b/.github/workflows/monthly-release.yaml
@@ -78,6 +78,7 @@ jobs:
         run: |
           sed -i -E "s|(\s*<version>)([0-9.]+)(</version>\s*)|\1${CURRENT_TAG}\3|" choco/tinytex.nuspec
           sed -i -E "s|(\s*checksum\s*=\s*')([^']*)('\\s*)|\1${TINYTEX_MD5SUM}\3|" choco/tools/chocolateyinstall.ps1
+          sed -i -E "s|($version\s*=\s*')([0-9.]+)('\s*)|\1${CURRENT_TAG}\3|" choco/tools/chocolateyinstall.ps1
           git add -u
           git diff-index --quiet HEAD && exit 0 || git commit -m"TinyTeX release v${CURRENT_TAG}"
 

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop';
+$version = '2023.07';
 $toolsDir = Get-ToolsLocation
-$url        = "https://github.com/rstudio/tinytex-releases/releases/download/v$($env:ChocolateyPackageVersion)/TinyTeX-1-v$($env:ChocolateyPackageVersion).zip"
+$url        = "https://github.com/rstudio/tinytex-releases/releases/download/v$($version)/TinyTeX-1-v$($version).zip"
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir


### PR DESCRIPTION
There is a breaking change where chocolatey
does something weird with that.

fixes https://github.com/rstudio/tinytex-releases/issues/39